### PR TITLE
add quantization parameters for transformers models

### DIFF
--- a/guidance/llms/_transformers.py
+++ b/guidance/llms/_transformers.py
@@ -14,7 +14,8 @@ class Transformers(LLM):
 
     cache = LLM._open_cache("_transformers.diskcache")
 
-    def __init__(self, model=None, tokenizer=None, caching=True, token_healing=True, acceleration=True, temperature=0.0, device=None, device_map=None, role_start=None, role_end=None):
+    def __init__(self, model=None, tokenizer=None, caching=True, token_healing=True, acceleration=True, \
+                 temperature=0.0, device=None, device_map=None, role_start=None, role_end=None, **kwargs):
         super().__init__()
 
         # fill in default model value
@@ -27,7 +28,7 @@ class Transformers(LLM):
             except:
                 pass
 
-        self.model_obj, self._tokenizer = self._model_and_tokenizer(model, tokenizer, device_map)
+        self.model_obj, self._tokenizer = self._model_and_tokenizer(model, tokenizer, device_map, **kwargs)
         self._generate_call = self.model_obj.generate
 
         self.model_name = model
@@ -117,7 +118,7 @@ class Transformers(LLM):
 
         return token_map
 
-    def _model_and_tokenizer(self, model, tokenizer, device_map):
+    def _model_and_tokenizer(self, model, tokenizer, device_map, **kwargs):
 
         # make sure transformers is installed
         try:
@@ -128,8 +129,8 @@ class Transformers(LLM):
         # intantiate the model and tokenizer if needed
         if isinstance(model, str):
             if tokenizer is None:
-                tokenizer = transformers.AutoTokenizer.from_pretrained(model, device_map=device_map)
-            model = transformers.AutoModelForCausalLM.from_pretrained(model, device_map=device_map)
+                tokenizer = transformers.AutoTokenizer.from_pretrained(model, device_map=device_map, **kwargs)
+            model = transformers.AutoModelForCausalLM.from_pretrained(model, device_map=device_map, **kwargs)
         
         assert tokenizer is not None, "You must give a tokenizer object when you provide a model object (as opposed to just a model name)!"
             

--- a/guidance/llms/transformers/_llama.py
+++ b/guidance/llms/transformers/_llama.py
@@ -15,7 +15,8 @@ class LLaMA(Transformers):
 
     cache = LLM._open_cache("_llama.diskcache")
 
-    def __init__(self, model, tokenizer=None, device_map=None, **kwargs):
+    def __init__(self, model, tokenizer=None, caching=True, token_healing=True, \
+                 acceleration=True, temperature=0.0, device=None, device_map=None, **kwargs):
         """ Create a new LLaMA model.
         """
 
@@ -23,7 +24,8 @@ class LLaMA(Transformers):
         import transformers
         if isinstance(model, str):
             if tokenizer is None:
-                tokenizer = transformers.LlamaTokenizer.from_pretrained(model, device_map=device_map)
-            model = transformers.LlamaForCausalLM.from_pretrained(model, device_map=device_map)
+                tokenizer = transformers.LlamaTokenizer.from_pretrained(model, device_map=device_map, **kwargs)
+            model = transformers.LlamaForCausalLM.from_pretrained(model, device_map=device_map, **kwargs)
 
-        super().__init__(model, tokenizer=tokenizer, device_map=device_map, **kwargs)
+        super().__init__(model, tokenizer=tokenizer, caching=caching, token_healing=token_healing, \
+                         acceleration=acceleration, temperature=temperature, device=device, device_map=device_map, **kwargs)

--- a/guidance/llms/transformers/_mpt.py
+++ b/guidance/llms/transformers/_mpt.py
@@ -15,7 +15,8 @@ class MPT(Transformers):
 
     cache = LLM._open_cache("_mpt.diskcache")
 
-    def __init__(self, model, tokenizer=None, max_seq_len=None, attn_impl=None, device_map=None, **kwargs):
+    def __init__(self, model, tokenizer=None, max_seq_len=None, attn_impl=None, caching=True, \
+                 token_healing=True, acceleration=True, temperature=0.0, device=None, device_map=None, **kwargs):
         """ Create a new LLaMA model.
         """
 
@@ -25,7 +26,7 @@ class MPT(Transformers):
 
             # MPT uses the same tokenizer as GPT-NeoX
             if tokenizer is None:
-                tokenizer = tokenizer = transformers.AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b", device_map=device_map)
+                tokenizer = tokenizer = transformers.AutoTokenizer.from_pretrained("EleutherAI/gpt-neox-20b", device_map=device_map, **kwargs)
             
             dynamic_kwargs = {}
 
@@ -48,10 +49,12 @@ class MPT(Transformers):
             model = transformers.AutoModelForCausalLM.from_pretrained(
                 model,
                 config=config,
-                trust_remote_code=True
+                trust_remote_code=True,
+                **kwargs
             )
 
-        super().__init__(model, tokenizer=tokenizer, device_map=device_map, **kwargs)
+        super().__init__(model, tokenizer=tokenizer, caching=caching, token_healing=token_healing, \
+                         acceleration=acceleration, temperature=temperature, device=device, device_map=device_map, **kwargs)
 
 class MPTChat(MPT):
 


### PR DESCRIPTION
This adds the `torch_dtype` and `load_in_8bit` quantization parameters for `transformers` models that allow loading larger models with lower VRAM requirements. 

The Llama and MPT subclasses load the model directly, so the parameters had to duplicated there. MPT doesn't seem to support `load_in_8bit` yet, so I just included `torch_dtype` for that one