### PR TITLE
fix: Add missing msal dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "platformdirs",
         "tiktoken>=0.3",
         "nest_asyncio",
+        "msal",
         "requests",
         "numpy"
     ],


### PR DESCRIPTION
Add `msal` as a dependency since it is imported in the constructor for `guidance.llms.AzureOpenAI`.