### PR TITLE
Ensure get_ipython is available even in callbacks

### DIFF
--- a/guidance/_program.py
+++ b/guidance/_program.py
@@ -121,6 +121,7 @@ class Program:
 
         # see if we are in an ipython environment
         try:
+            from IPython import get_ipython
             self._ipython = get_ipython()
         except:
             self._ipython = None


### PR DESCRIPTION
It'd be good to ensure that streaming results are available even in the context of an ipywidget callback, like https://github.com/jmandel/guidance-guidance/blob/main/Quiz%20with%20Form%20WIP.ipynb

Importing the `get_ipython` function fixes this for me.