### PR TITLE
Support models that doesn't output `past_key_values`

### DIFF
--- a/guidance/llms/_transformers.py
+++ b/guidance/llms/_transformers.py
@@ -196,7 +196,7 @@ class TransformersSession(LLMSession):
                 def decorate_update_step(outputs, *args, **kwargs):
 
                     # save the past key values
-                    self._past_key_values = outputs.past_key_values
+                    self._past_key_values = getattr(outputs, "past_key_values", None)
 
                     return method(outputs, *args, **kwargs)
                 return decorate_update_step


### PR DESCRIPTION
# What does this PR do?

Originally pointed out in https://github.com/huggingface/transformers/pull/22797#issuecomment-1556318702 by @fullstackwebdev

By design, some models in `transformers` does not output `past_key_value`. 
This is the case for a new architecture called [RWKV](https://huggingface.co/blog/rwkv), recently integrated in Hugging Face's `transformers`: https://github.com/huggingface/transformers/pull/22797 
For that specific architecture, it is an 'attention free' LLM that does not rely on past key value mechanism to return the cache of the model, as the tokens are always processed one by one. 
This PR adds the support of these custom models, by returning `None` if `past_key_values` is not present in the model's output. The generate method should automatically take care of the rest under the hood in `transformers`.

# To reproduce

Simply run the snippet below: 
```python
import guidance
# we use StableLM as an open example, but these issues impact all models to varying degrees
guidance.llm = guidance.llms.Transformers("RWKV/rwkv-4-169m-pile", device=0)

# we turn token healing off so that guidance acts like a normal prompting library
program = guidance('''Hello my name is {{gen max_tokens=10}}''')
print(program())
```

@slundberg 