### PR TITLE
Add gpt-4-32k and gpt-4-32k-0314 to OpenAI Models

### DIFF
--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -58,6 +58,7 @@ def add_text_to_chat_mode(chat_mode):
 chat_models = [
     "gpt-4",
     "gpt-3.5-turbo",
+    "gpt-4-32k",
     "gpt-4-0314",
     "gpt-3.5-turbo-0301"
 ]

--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -57,9 +57,10 @@ def add_text_to_chat_mode(chat_mode):
 # model that need to use the chat completion API
 chat_models = [
     "gpt-4",
-    "gpt-3.5-turbo",
     "gpt-4-32k",
     "gpt-4-0314",
+    "gpt-4-32k-0314",
+    "gpt-3.5-turbo",
     "gpt-3.5-turbo-0301"
 ]
 


### PR DESCRIPTION
Simply adds `gpt-4-32k` and `gpt-4-32k-0314` to the list of OpenAI models and a newline at the end of file. 

Closes https://github.com/microsoft/guidance/issues/77