### PR TITLE
Fix TypeError when serializing out.variables() to JSON

### DIFF
--- a/notebooks/guaranteeing_valid_syntax.ipynb
+++ b/notebooks/guaranteeing_valid_syntax.ipynb
@@ -177,12 +177,25 @@
     }
    ],
    "source": [
-    "# ...that we could also use to generate compressed JSON\n",
+    "# ...that we could also selectively serialize the dictionary to JSON\n",
     "import json\n",
-    "json.dumps(out.variables())"
+    "\n",
+    "# Retrieve the dictionary of all variables from out.variables()\n",
+    "all_variables = out.variables()\n",
+    "\n",
+    "# Specify the keys of interest\n",
+    "desired_keys = ['description', 'valid_weapons', 'name', 'age', 'armor', 'weapon', 'class', 'mantra', 'strength', 'items']\n",
+    "\n",
+    "# Create a new dictionary containing only the desired keys\n",
+    "filtered_variables = {key: all_variables[key] for key in desired_keys}\n",
+    "\n",
+    "# Serialize the filtered dictionary into JSON\n",
+    "json_data = json.dumps(filtered_variables)\n",
+    "print(json_data)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Fixes #112

This PR resolves an issue where attempting to serialize the output of out.variables() to JSON results in a TypeError.

The issue arises when trying to serialize the dictionary returned by out.variables() which includes a Transformers object associated with the key 'llm', which is not JSON serializable.

In the proposed change, we selectively serialize only the necessary keys to JSON, effectively bypassing the issue caused by the 'llm' key.

Here's a simplified view of the changes:

```
import json

# Retrieve the dictionary of all variables from out.variables()
all_variables = out.variables()

# Specify the keys of interest
desired_keys = ['description', 'valid_weapons', 'name', 'age', 'armor', 'weapon', 'class', 'mantra', 'strength', 'items']

# Create a new dictionary containing only the desired keys
filtered_variables = {key: all_variables[key] for key in desired_keys}

# Serialize the filtered dictionary into JSON
json_data = json.dumps(filtered_variables)
print(json_data)
```