### PR TITLE
add timeout parameter to POST request

### DIFF
--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -309,7 +309,7 @@ class OpenAI(LLM):
         # Send a POST request and get the response
         # An exception for timeout is raised if the server has not issued a response for 10 seconds
         try:
-            response = requests.post(self.endpoint, headers=headers, json=data, stream=stream, timeout=10)
+            response = requests.post(self.endpoint, headers=headers, json=data, stream=stream, timeout=60)
             if response.status_code != 200:
                 raise Exception("Response is not 200: " + response.text)
             if stream:

--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -307,13 +307,20 @@ class OpenAI(LLM):
             del data['logprobs']
 
         # Send a POST request and get the response
-        response = requests.post(self.endpoint, headers=headers, json=data, stream=stream)
-        if response.status_code != 200:
-            raise Exception("Response is not 200: " + response.text)
-        if stream:
-            return self._rest_stream_handler(response)
-        else:
-            response = response.json()
+        # An exception for timeout is raised if the server has not issued a response for 10 seconds
+        try:
+            response = requests.post(self.endpoint, headers=headers, json=data, stream=stream, timeout=10)
+            if response.status_code != 200:
+                raise Exception("Response is not 200: " + response.text)
+            if stream:
+                return self._rest_stream_handler(response)
+            else:
+                response = response.json()
+        except requests.Timeout:
+            raise Exception("Request timed out.")
+        except requests.ConnectionError:
+            raise Exception("Connection error occurred.")
+
         if self.chat_mode:
             response = add_text_to_chat_mode(response)
         return response


### PR DESCRIPTION
Add a timeout parameter to the POST request to avoid waiting/hanging when the endpoint is unresponsive. A default value of 10 is set for the timeout parameter, which will wait for 10 secs before raising an exception for timeout.