### PR TITLE
Fix GPT proverb example with multiple gens

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ program = guidance("""Tweak this proverb to apply to model instructions instead.
 
 UPDATED
 Where there is no guidance{{gen 'rewrite' stop="\\n-"}}
-- GPT {{gen 'chapter'}}:{{gen 'verse'}}""")
+- GPT {{gen 'chapter' stop=":"}}:{{gen 'verse'}}""")
 
 # execute the program on a specific proverb
 executed_program = program(


### PR DESCRIPTION
It seems for prompt that (1) provides an example format and (2) has multiple `gen`s, all but the last `gen` need to have proper stop in order to avoid LLM generating all following contents directly. 

The  proverb example in README doesn't provide the stop attribute for `chapter` variable. This will cause it to actually return a completion like `- GPT  11:14:1` which doesn't follow the intended format. This PR fixes this and hopefully makes the point about multi-gen more clear. 