### PR TITLE
add support for openai dynamic max tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,3 +724,24 @@ See a more elaborate example [here](notebooks/chat.ipynb).
 
 ### Using tools
 See the 'Using a search API' example in [this notebook](notebooks/chat.ipynb).
+
+
+## LLM specific functionality
+
+### OpenAI Dynamic Max Tokens
+
+OpenAI LLM supports setting the max_tokens argument to gen calls dynamically using a callback function which gets the
+allows max tokens the model supports and the number of tokens in the current prompt.
+
+The following example will use all tokens available in the model minus the number of tokens in the prompt to generate
+the story:
+
+```python
+guidance.llm = guidance.llms.OpenAI("text-davinci-003")
+guidance.llm.register_max_tokens_callback('use_all_tokens', lambda model_max_tokens, num_prompt_tokens: model_max_tokens - num_prompt_tokens)
+res = guidance('''
+A long story about cars:
+{{gen 'story' max_tokens_callback='use_all_tokens'}}
+{{~/assistant}}
+''')['story']
+```

--- a/guidance/library/_gen.py
+++ b/guidance/library/_gen.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_tokens=500, n=1, stream=None,
               temperature=0.0, top_p=1.0, logprobs=None, pattern=None, hidden=False, list_append=False,
-              save_prompt=False, token_healing=None, _parser_context=None):
+              save_prompt=False, token_healing=None, _parser_context=None, **llm_kwargs):
     ''' Use the LLM to generate a completion.
 
     Parameters
@@ -55,6 +55,8 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
         If set to a string, the exact prompt given to the LLM will be saved in a variable with the given name.
     token_healing : bool or None
         If set to a bool this overrides the token_healing setting for the LLM.
+    **llm_kwargs: dict
+        Additional keyword arguments will be passed to the LLM call.
     '''
     prefix = ""
     suffix = ""
@@ -137,7 +139,7 @@ async def gen(name=None, stop=None, stop_regex=None, save_stop_text=False, max_t
     gen_obj = await parser.llm_session(
         parser_prefix+prefix, stop=stop, stop_regex=stop_regex, max_tokens=max_tokens, n=n, pattern=pattern,
         temperature=temperature, top_p=top_p, logprobs=logprobs, cache_seed=cache_seed, token_healing=token_healing,
-        echo=parser.program.logprobs is not None, stream=stream, caching=parser.program.caching
+        echo=parser.program.logprobs is not None, stream=stream, caching=parser.program.caching, **llm_kwargs
     )
 
     if n == 1:

--- a/guidance/llms/_mock.py
+++ b/guidance/llms/_mock.py
@@ -41,12 +41,12 @@ class Mock(LLM):
             if prompt.endswith(key):
                 return key
 
-    def __call__(self, prompt, *args, n=1, stream=False, **kwargs):
+    def __call__(self, prompt, *args, n=1, stream=False, mock_llm_out_override=None, **kwargs):
         key = self._find_suffix_match(prompt)
         output = self.output[key]
         choices = []
         for i in range(n):
-            out = output[min(self.counts[key], len(output)-1)]
+            out = mock_llm_out_override if mock_llm_out_override else output[min(self.counts[key], len(output)-1)]
             self.counts[key] += 1
             if isinstance(out, str):
                 choices.append({"text": out, "finish_reason": "stop"})

--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -72,7 +72,6 @@ def num_tokens_from_messages(messages, model):
         tokens_per_message = 4
     elif model.startswith('gpt-4'):
         tokens_per_message = 3
-        tokens_per_name = 1
     else:
         raise NotImplementedError(f"""num_tokens_from_messages() is not implemented for model {model}.""")
     num_tokens = 0

--- a/tests/library/test_gen.py
+++ b/tests/library/test_gen.py
@@ -101,3 +101,9 @@ def test_gen_stream(llm):
     prompt = guidance("Hello my name is{{gen 'name' max_tokens=10 stream=True}}", llm=llm2)
     out = prompt()
     assert len(out["name"]) > 1
+
+def test_gen_llm_kwargs():
+    llm = guidance.llms.Mock(" Sue")
+    prompt = guidance("Hello my name is{{gen 'name' mock_llm_out_override=' Tom'}}", llm=llm)
+    out = prompt()
+    assert out["name"] == ' Tom'

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -1,5 +1,20 @@
 import guidance
+import tiktoken
 from ..utils import get_openai_llm
+
+def assert_dynamic_max_tokens(model_name, prompt, expected_test_data):
+    guidance.llm = get_openai_llm(model_name)
+    enc = tiktoken.encoding_for_model(guidance.llm.model_name)
+    test_data = {}
+
+    def max_tokens_callback_test(model_max_tokens, prompt_num_tokens):
+        test_data.update(model_max_tokens=model_max_tokens, prompt_num_tokens=prompt_num_tokens)
+        return 2
+
+    guidance.llm.register_max_tokens_callback('test', max_tokens_callback_test)
+    out = guidance(prompt)()
+    assert len(enc.encode(out["res"])) == 2
+    assert test_data == expected_test_data
 
 def test_geneach_chat_gpt():
     """ Test a geneach loop with ChatGPT.
@@ -25,3 +40,30 @@ def test_geneach_chat_gpt():
 
     out = chat_loop()
     assert len(out["conversation"]) == 2
+
+def test_dynamic_max_tokens():
+    """ Test OpenAI generating a response with dynamic max tokens.
+    """
+    assert_dynamic_max_tokens(
+        "text-davinci-003",
+        '''
+        Short story about cars:
+        {{gen 'res' max_tokens=500 max_tokens_callback='test'}}
+        ''',
+        {'model_max_tokens': 4097, 'prompt_num_tokens': 9}
+    )
+    assert_dynamic_max_tokens(
+        "gpt-3.5-turbo",
+        '''
+        {{#system~}}
+        You are a helpful assistant
+        {{~/system}}
+        {{#user~}}
+        Hello, please write a short story
+        {{~/user}}
+        {{#assistant~}}
+        {{gen 'res' max_tokens=500 max_tokens_callback='test'}}
+        {{~/assistant}}
+        ''',
+        {'model_max_tokens': 4096, 'prompt_num_tokens': 30}
+    )

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -48,7 +48,7 @@ def test_dynamic_max_tokens():
         "text-davinci-003",
         '''
         Short story about cars:
-        {{gen 'res' max_tokens=500 max_tokens_callback='test'}}
+        {{gen 'res' max_tokens_callback='test'}}
         ''',
         {'model_max_tokens': 4097, 'prompt_num_tokens': 9}
     )
@@ -62,7 +62,7 @@ def test_dynamic_max_tokens():
         Hello, please write a short story
         {{~/user}}
         {{#assistant~}}
-        {{gen 'res' max_tokens=500 max_tokens_callback='test'}}
+        {{gen 'res' max_tokens_callback='test'}}
         {{~/assistant}}
         ''',
         {'model_max_tokens': 4096, 'prompt_num_tokens': 30}


### PR DESCRIPTION
* add support for kwargs in gen calls to be passed to the llm call - allowing for llm specific functionality
* use this feature to add a dynamic max tokens option to OpenAI allowing to set the max tokens dynamically based on the model allowed max tokens and the number of tokens in the prompt, see the updated README for details: https://github.com/OriHoch/guidance/blob/add-support-for-llm-call-kwargs-add-openai-dynamic-max-tokens/README.md#openai-dynamic-max-tokens