### PR TITLE
Fix partials and empty blocks

### DIFF
--- a/guidance/_program_executor.py
+++ b/guidance/_program_executor.py
@@ -467,8 +467,7 @@ class ProgramExecutor():
         return default_value # variable not found
 
     def variable_exists(self, name):
-        out = self.get_variable(name, 849203984939)
-        return out != 849203984939
+        return self.get_variable(name, _NO_VALUE) != _NO_VALUE
 
     def set_variable(self, name, value):
         parts = re.split(r"\.|\[", name)

--- a/guidance/library/_block.py
+++ b/guidance/library/_block.py
@@ -22,7 +22,8 @@ async def block(name=None, hidden=False, _parser_context=None):
         prev_node=_parser_context["prev_node"]
     )
     if name is not None:
-        parser.set_variable(name, strip_markers(out))
+        variable_value = strip_markers(out) if out is not None else None
+        parser.set_variable(name, variable_value)
     if hidden:
         new_content = parser.prefix[pos:]
         parser.reset_prefix(pos)

--- a/tests/library/test_block.py
+++ b/tests/library/test_block.py
@@ -1,9 +1,20 @@
 import guidance
+from ..utils import get_llm
 
 def test_hidden_block():
-    """ Test the behavior of `if` with an `else` clause.
+    """ Test the behavior of generic `block`.
     """
 
     prompt = guidance("""This is a test {{#block hidden=True}}example{{/block}}""")
     out = prompt()
     assert out.text == "This is a test "
+
+def test_empty_block():
+    """ Test the behavior of a completely empty `block`.
+    """
+
+    prompt = guidance(
+        "{{#block}}{{#if nonempty}}nonempty{{/if}}{{/block}}",
+    )
+    out = prompt(nonempty=False)
+    assert out.text == ''

--- a/tests/library/test_include.py
+++ b/tests/library/test_include.py
@@ -1,0 +1,70 @@
+import guidance
+import pytest
+
+from ..utils import get_llm
+
+SKIP_BASELINE_TESTS=True
+
+@pytest.mark.skipif(SKIP_BASELINE_TESTS, reason="Does not test include tag; provides a baseline for in the event of a regression.")
+def test_guidance_capture_baseline():
+    program = guidance(
+        "It is {{context.holiday}}! {{input}} {{gen 'response'}}",
+        llm=get_llm('transformers:gpt2')
+    )
+    output = program(
+        input="What are some favorite pirate songs?",
+        context=dict(holiday="Talk Like a Pirate Day"),
+    )
+    assert len(output["response"]) > 1, "Expected to capture response"
+
+
+def test_guidance_capture_include():
+    include_program = guidance("It is {{context.holiday}}!")
+    program = guidance(
+        "{{>include_program}} {{input}} {{gen 'response'}}",
+        llm=get_llm('transformers:gpt2')
+    )
+    output = program(
+        include_program=include_program,
+        input="What are some favorite pirate songs?",
+        context=dict(holiday="Talk Like a Pirate Day"),
+    )
+    assert len(output["response"]) > 1
+
+@pytest.mark.skipif(SKIP_BASELINE_TESTS, reason="Does not test include tag; provides a baseline for in the event of a regression.")
+def test_guidance_capture_baseline():
+    program = guidance(
+        "{{#if context}}It is {{context.holiday}}! {{/if}}{{input}} {{gen 'response'}}",
+        llm=get_llm('transformers:gpt2')
+    )
+    output = program(
+        input="What are some favorite pirate songs?",
+        context=dict(holiday="Talk Like a Pirate Day"),
+    )
+    assert len(output["response"]) > 1, "Expected to capture response"
+
+def test_guidance_capture_include_with_if():
+    include_program = guidance("{{#if context}}It is {{context.holiday}}! {{/if}}")
+    program = guidance(
+        "{{>include_program}}{{input}} {{gen 'response'}}",
+        llm=get_llm('transformers:gpt2')
+    )
+    output = program(
+        include_program=include_program,
+        context=dict(holiday="Talk Like a Pirate Day"),
+        input="What are some favorite pirate songs?",
+    )
+    assert len(output["response"]) > 1
+
+def test_guidance_capture_include_output_with_if():
+    include_program = guidance("{{#if context}}It is {{context.holiday}}! {{/if}}")
+    include_output = include_program(context=dict(holiday="Talk Like a Pirate Day"))
+    program = guidance(
+        "{{>include_output}}{{input}} {{gen 'response'}}", 
+        llm=get_llm('transformers:gpt2')
+    )
+    output = program(
+        include_output=include_output,
+        input="What are some favorite pirate songs?",
+    ) 
+    assert len(output["response"]) > 1, "Expected to capture response"

--- a/tests/library/test_include.py
+++ b/tests/library/test_include.py
@@ -5,7 +5,7 @@ from ..utils import get_llm
 
 SKIP_BASELINE_TESTS=True
 
-@pytest.mark.skipif(SKIP_BASELINE_TESTS, reason="Does not test include tag; provides a baseline for in the event of a regression.")
+@pytest.mark.skipif(SKIP_BASELINE_TESTS, reason="Does not test include tag; provides a baseline for comparison in the event of a regression.")
 def test_guidance_capture_baseline():
     program = guidance(
         "It is {{context.holiday}}! {{input}} {{gen 'response'}}",

--- a/tests/library/test_set.py
+++ b/tests/library/test_set.py
@@ -9,3 +9,6 @@ def test_set():
     
     program = guidance("""{{set 'output' 234 hidden=True}}{{output}}""")
     assert str(program()) == "234"
+
+    program = guidance("""{{set 'output' 849203984939}}{{output}}""")
+    assert str(program()['output']) == "849203984939"


### PR DESCRIPTION
I had some trouble trying to do template composition. There were ultimately two significant issues:
1. Output variables didn't seem to work after using a template partial include. I could work around this by executing the templates to be included serially, but this didn't seem to align to design intent.
2. Empty partials threw an error in strip_markers because a None was being passed.

I wrote some tests to understand the issue, and found that:
1. `ProgramExecutor` seemed to be designed to keep a _reference_ stack_ of variables from its stack of `Programs`, but template partials caused the variable map to be rebuild, breaking the association.
2. The `block` function could easily be modified to avoid calling `strip_markers` on `None`, which seemed fine because that's not going to contain any markers.

This fixes #153 , #154.