### PR TITLE
Remove the last empty assistant message for ChatGPT API call

### DIFF
--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -24,7 +24,7 @@ def prompt_to_messages(prompt):
 
     assert prompt.endswith("<|im_start|>assistant\n"), "When calling OpenAI chat models you must generate only directly inside the assistant role! The OpenAI API does not currently support partial assistant prompting."
 
-    pattern = r'<\|im_start\|>(\w+)(.*?)(?=<\|im_end\|>|$)'
+    pattern = r'<\|im_start\|>(\w+)(.*?)(?=<\|im_end\|>)'
     matches = re.findall(pattern, prompt, re.DOTALL)
 
     if not matches:

--- a/guidance/llms/_openai.py
+++ b/guidance/llms/_openai.py
@@ -24,7 +24,7 @@ def prompt_to_messages(prompt):
 
     assert prompt.endswith("<|im_start|>assistant\n"), "When calling OpenAI chat models you must generate only directly inside the assistant role! The OpenAI API does not currently support partial assistant prompting."
 
-    pattern = r'<\|im_start\|>(\w+)(.*?)(?=<\|im_end\|>)'
+    pattern = r'<\|im_start\|>(\w+)\n(.*?)(?=<\|im_end\|>|$)'
     matches = re.findall(pattern, prompt, re.DOTALL)
 
     if not matches:
@@ -32,8 +32,8 @@ def prompt_to_messages(prompt):
 
     for match in matches:
         role, content = match
-        content = content.strip() # should we do this?
-        messages.append({'role': role, 'content': content})
+        if len(content) > 0: # only add non-empty messages (OpenAI does not support empty messages anyway)
+            messages.append({'role': role, 'content': content})
 
     return messages
 


### PR DESCRIPTION
Due to the way the regex was written, currently there is always an empty message produced at the end of messages list, eg:
`[{'role': 'system', 'content': 'You are a helpful assistant.'}, {'role': 'user', 'content': 'Whats is the meaning of life??'}, {'role': 'assistant', 'content': ''}]`.

This PR fix the regex and thus remove this empty message.
