### PR TITLE
fix: 're' not defined error

### DIFF
--- a/guidance/library/_each.py
+++ b/guidance/library/_each.py
@@ -1,5 +1,6 @@
 import asyncio
 import builtins
+import re
 from .._utils import ContentCapture
 
 async def each(list, hidden=False, parallel=False, item_name="this", start_index=0, _parser_context=None):


### PR DESCRIPTION
I observed the error:

```
    updated_text = re.sub(r"^({{~?#each.*?)(~?}})", r"\1 start_index="+str(i+1)+r"\2", _parser_context["parser_node"].text)
NameError: name 're' is not defined
Error in program:  name 're' is not defined
```

when attempting to use `tool_def` for function usage.

